### PR TITLE
Preventing the `data_orig` from being polluted

### DIFF
--- a/tests/unit/test_meta_for_old_files.py
+++ b/tests/unit/test_meta_for_old_files.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 import numpy.ma as ma
 from cloudnetpy.plotting import meta_for_old_files
@@ -16,7 +17,8 @@ def test_fix_old_data():
 
 
 def test_fix_old_data_2():
-    data, name = meta_for_old_files.fix_old_data(data_orig, 'detection_status')
-    assert_array_equal(data_orig, data)
+    od = copy.deepcopy(data_orig)
+    data, name = meta_for_old_files.fix_old_data(od, 'detection_status')
+    assert_array_equal(od, data)
     assert ma.count(data) == 7
 


### PR DESCRIPTION
The PR aims to improve the reliability of the test `test_fix_old_data_2` in `test_meta_for_old_files.py` by preventing `data_orig` from being polluted by calling the method `copy.deepcopy`.

The test can fail in the following way if `data_orig` gets polluted:
```
E       assert 5 == 7
E        +  where 5 = <numpy.ma.core._frommethod object at 0x7f462a6879d0>(masked_array(\n  data=[[0, 1, 2],\n        [3, --, 5],\n        [--, --, --]],\n  mask=[[False, False, False],\n        [False,  True, False],\n        [ True,  True,  True]],\n  fill_value=999999))
E        +    where <numpy.ma.core._frommethod object at 0x7f462a6879d0> = ma.count
```